### PR TITLE
Implement service unlocking

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -5,10 +5,24 @@
 #include "memchunkhax2.h"
 
 int main(int argc, char **argv) {
+    Handle amHandle = 0;
+    Result res;
+    u8 success;
+
     gfxInitDefault();
     consoleInit(GFX_TOP, NULL);
 
-    execute_memchunkhax2();
+    // This one should fail
+    res = srvGetServiceHandleDirect(&amHandle, "am:u");
+    printf("am:u init1 result/handle: %lu, %lu\n", res, amHandle);
+
+    // Run the exploit
+    success = execute_memchunkhax2();
+    printf("Exploit returned: %s\n", success ? "Success!" : "Failure.");
+
+    // This one hopefully won't
+    res = srvGetServiceHandleDirect(&amHandle, "am:u");
+    printf("am:u init2 result/handle: %lu, %lu\n", res, amHandle);
 
     printf("Press START to exit.\n");
 

--- a/source/main.c
+++ b/source/main.c
@@ -14,7 +14,10 @@ int main(int argc, char **argv) {
 
     // This one should fail
     res = srvGetServiceHandleDirect(&amHandle, "am:u");
-    printf("am:u init1 result/handle: %lu, %lu\n", res, amHandle);
+    printf("am:u init1 result/handle: res=%lu handle=%lu\n", res, amHandle);
+    if(amHandle) {
+        svcCloseHandle(amHandle);
+    }
 
     // Run the exploit
     success = execute_memchunkhax2();
@@ -22,7 +25,10 @@ int main(int argc, char **argv) {
 
     // This one hopefully won't
     res = srvGetServiceHandleDirect(&amHandle, "am:u");
-    printf("am:u init2 result/handle: %lu, %lu\n", res, amHandle);
+    printf("am:u init2 result/handle: res=%lu handle=%lu\n", res, amHandle);
+    if(amHandle) {
+        svcCloseHandle(amHandle);
+    }
 
     printf("Press START to exit.\n");
 

--- a/source/memchunkhax2.c
+++ b/source/memchunkhax2.c
@@ -79,7 +79,6 @@ static void km_stage1() {
     sprintf(DEBUGBUF_NEXT, "proc at %p\n", proc);
     u8 *procacl = proc + OLDNEW(KPROCESS_ACL_START);
     memset(procacl, 0xFF, SVC_ACL_SIZE);
-    sprintf(DEBUGBUF_NEXT, "proc svc acl overwritten\n");
 
     // Now patch the current thread.
     u8 *thread = (u8*)CURRENT_KTHREAD;
@@ -102,7 +101,6 @@ static s32 kmbackdoor_pid_zero(void) {
     originalPid = km_get_process_pid();
     sprintf(DEBUGBUF_NEXT, "old pid is %lu\n", originalPid);
     km_patch_process_pid(0);
-    sprintf(DEBUGBUF_NEXT, "patched pid is %lu\n", km_get_process_pid());
     
     // We're now PID zero, all we have to do is reinitialize the service manager in user-mode.
     return 0;
@@ -112,9 +110,7 @@ static s32 kmbackdoor_pid_zero(void) {
 static s32 kmbackdoor_pid_reset(void) {
     __asm__ volatile("cpsid aif");
     
-    sprintf(DEBUGBUF_NEXT, "old pid is %lu\n", km_get_process_pid());
     km_patch_process_pid(originalPid);
-    sprintf(DEBUGBUF_NEXT, "patched pid is %lu\n", km_get_process_pid());
 
     // Back to normal.
     return 0;
@@ -154,7 +150,7 @@ static Result __attribute__((naked)) svcCreateEventKAddr(Handle* event, u8 reset
 
 // Executes exploit.
 static u8 memchunkhax2_exploit() {
-    printf("Setting up...\n");
+    printf("Setting up firm=%ld kernel=%ld\n", osGetFirmVersion(), osGetKernelVersion());
     
     // Set up variables.
     Handle arbiter = __sync_get_arbiter();
@@ -343,7 +339,6 @@ static u8 memchunkhax2_service_unlock() {
     printf("Reinitializing srv\n");
     srvExit();
     srvInit();
-    printf("srv reinitialized.\n");
 
     svcBackdoor(kmbackdoor_pid_reset);
     debugbuf_out();

--- a/source/memchunkhax2.h
+++ b/source/memchunkhax2.h
@@ -1,3 +1,11 @@
 #pragma once
 
-void execute_memchunkhax2();
+#include <3ds.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    u8 execute_memchunkhax2();
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
The unlocking seems stable. No changes to the initial kernel entry process or stability of the system on exit.

Could probably have more debug messages toned down and/or the debug buffer removed entirely, but this works.